### PR TITLE
Neuer Abrechnungsmodus "abgemeldete Mitglieder" eingeführt.

### DIFF
--- a/src/de/jost_net/JVerein/gui/input/AbbuchungsmodusInput.java
+++ b/src/de/jost_net/JVerein/gui/input/AbbuchungsmodusInput.java
@@ -52,6 +52,7 @@ public class AbbuchungsmodusInput extends SelectInput
       case FLEXIBEL:
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.ALLE));
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.EINGETRETENEMITGLIEDER));
+        l.add(new AbbuchungsmodusObject(Abrechnungsmodi.ABGEMELDETEMITGLIEDER));
         break;
       case MONATLICH12631:
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.JAHAVIMO));
@@ -63,6 +64,7 @@ public class AbbuchungsmodusInput extends SelectInput
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.VI));
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.MO));
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.EINGETRETENEMITGLIEDER));
+        l.add(new AbbuchungsmodusObject(Abrechnungsmodi.ABGEMELDETEMITGLIEDER));
         break;
     }
     return PseudoIterator.fromArray(l.toArray(new AbbuchungsmodusObject[l

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -250,8 +250,18 @@ public class AbrechnungSEPA
       list.addFilter("(eintritt <= ? or eintritt is null) ",
           new Object[] { new java.sql.Date(param.stichtag.getTime()) });
       // Das Mitglied darf noch nicht ausgetreten sein
-      list.addFilter("(austritt is null or austritt > ?)",
-          new Object[] { new java.sql.Date(param.stichtag.getTime()) });
+      // Bei Abbuchungen im Laufe des Jahres können optional nur die
+      // Mitglieder berücksichtigt werden, die schon abgemeldet sind.
+      if (param.abbuchungsmodus != Abrechnungsmodi.ABGEMELDETEMITGLIEDER)
+      {
+	      list.addFilter("(austritt is null or austritt > ?)",
+	          new Object[] { new java.sql.Date(param.stichtag.getTime()) });
+      }
+      else
+      {
+	      list.addFilter("(austritt > ?)",
+	          new Object[] { new java.sql.Date(param.stichtag.getTime()) });
+      }
       // Bei Abbuchungen im Laufe des Jahres werden nur die Mitglieder
       // berücksichtigt, die ab einem bestimmten Zeitpunkt eingetreten sind.
       if (param.vondatum != null)

--- a/src/de/jost_net/JVerein/keys/Abrechnungsmodi.java
+++ b/src/de/jost_net/JVerein/keys/Abrechnungsmodi.java
@@ -42,6 +42,8 @@ public class Abrechnungsmodi
   public static final int MO = 12;
 
   public static final int EINGETRETENEMITGLIEDER = 99;
+  
+  public static final int ABGEMELDETEMITGLIEDER = 100;
 
   private int abrechnungsmodus;
 
@@ -86,6 +88,8 @@ public class Abrechnungsmodi
         return "Vierteljahres- und Monatsbeiträge";
       case EINGETRETENEMITGLIEDER:
         return "eingetretene Mitglieder";
+      case ABGEMELDETEMITGLIEDER:
+          return "abgemeldete Mitglieder";
       default:
         return null;
     }


### PR DESCRIPTION
Hallo Heiner,

in unserem Verein buchen wir die Mitgliedsbeiträge zum Jahresende ab. Zusätzlich werden zweimal im Jahr Zusatzbeträge abgebucht. Um bei unterjährigen Austritten die Beiträge dieser Mitglieder vorzeitig (gemeinsam mit den Zusatzbeträgen) abbuchen zu können, habe ich einen neuen Abrechnungsmodus "abgemeldete Mitglieder" eingeführt. Damit werden die Beiträge der Mitglieder abgebucht,
die sich schon abgemeldet haben, deren Austrittsdatum aber nach dem
Stichtag ist.

Ich hoffe, Du bist mit den Änderungen einverstanden.

Viele Grüße
Reinhard