### PR TITLE
Abrechnungsmodus "abgemeldete Mitglieder" und Variable $lastschrift_geschlecht

### DIFF
--- a/src/de/jost_net/JVerein/Variable/LastschriftMap.java
+++ b/src/de/jost_net/JVerein/Variable/LastschriftMap.java
@@ -89,6 +89,7 @@ public class LastschriftMap
           abrl.getFaelligkeit2());
     }
     map.put(LastschriftVar.PERSONENART.getName(), ls.getPersonenart());
+    map.put(LastschriftVar.GESCHLECHT.getName(), ls.getGeschlecht());
     map.put(LastschriftVar.ANREDE.getName(), ls.getAnrede());
     map.put(LastschriftVar.ANREDE_DU.getName(),
         Adressaufbereitung.getAnredeDu(ls));

--- a/src/de/jost_net/JVerein/Variable/LastschriftVar.java
+++ b/src/de/jost_net/JVerein/Variable/LastschriftVar.java
@@ -24,6 +24,7 @@ public enum LastschriftVar
   ANREDE_DU("lastschrift_anrede_du"), //
   ANREDE_FOERMLICH("lastschrift_anrede_foermlich"), //
   PERSONENART("lastschrift_personenart"), //
+  GESCHLECHT("lastschrift_geschlecht"), //
   ANREDE("lastschrift_anrede"), //
   TITEL("lastschrift_titel"), //
   NAME("lastschrift_name"), //

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -69,6 +69,8 @@ public class AbrechnungSEPAControl extends AbstractControl
 
   private DateInput vondatum = null;
 
+  private DateInput bisdatum = null;
+
   private TextInput zahlungsgrund;
 
   private CheckboxInput zusatzbetrag;
@@ -122,6 +124,16 @@ public class AbrechnungSEPAControl extends AbstractControl
         {
           vondatum.setEnabled(true);
           vondatum.setValue(new Date());
+        }
+        if (m.intValue() != Abrechnungsmodi.ABGEMELDETEMITGLIEDER)
+        {
+          bisdatum.setValue(null);
+          bisdatum.setEnabled(false);
+        }
+        else
+        {
+          bisdatum.setEnabled(true);
+          bisdatum.setValue(new Date());
         }
       }
     });
@@ -188,6 +200,20 @@ public class AbrechnungSEPAControl extends AbstractControl
     this.vondatum.setText("Bitte Anfangsdatum der Abrechnung wählen");
     this.vondatum.setEnabled(false);
     return vondatum;
+  }
+
+  public DateInput getBisdatum()
+  {
+    if (bisdatum != null)
+    {
+      return bisdatum;
+    }
+    Date d = null;
+    this.bisdatum = new DateInput(d, new JVDateFormatTTMMJJJJ());
+    this.bisdatum.setTitle("Enddatum Abrechnung");
+    this.bisdatum.setText("Bitte maximales Austrittsdatum für die Abrechnung wählen");
+    this.bisdatum.setEnabled(false);
+    return bisdatum;
   }
 
   public TextInput getZahlungsgrund()
@@ -340,6 +366,11 @@ public class AbrechnungSEPAControl extends AbstractControl
       if (modus == Abrechnungsmodi.EINGETRETENEMITGLIEDER && vondatum == null)
       {
         throw new ApplicationException("von-Datum fehlt");
+      }
+      Date bisdatum = (Date) getBisdatum().getValue();
+      if (modus == Abrechnungsmodi.ABGEMELDETEMITGLIEDER && bisdatum == null)
+      {
+        throw new ApplicationException("bis-Datum fehlt");
       }
     }
     aa = (Abrechnungsausgabe) this.getAbbuchungsausgabe().getValue();

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -69,6 +69,8 @@ public class AbrechnungslaufControl extends AbstractControl
 
   private LabelInput eingabedatum;
 
+  private LabelInput austrittsdatum;
+
   private LabelInput zahlungsgrund;
 
   private LabelInput zusatzabrechnungen;
@@ -179,6 +181,18 @@ public class AbrechnungslaufControl extends AbstractControl
     eingabedatum = new LabelInput(new JVDateFormatTTMMJJJJ().format(ed));
     eingabedatum.setName("Eingabedatum");
     return eingabedatum;
+  }
+
+  public LabelInput getAustrittsdatum() throws RemoteException
+  {
+    if (austrittsdatum != null)
+    {
+      return austrittsdatum;
+    }
+    Date ed = getAbrechnungslaeufe().getAustrittsdatum();
+    austrittsdatum = new LabelInput(new JVDateFormatTTMMJJJJ().format(ed));
+    austrittsdatum.setName("Austrittsdatum");
+    return austrittsdatum;
   }
 
   public LabelInput getZahlungsgrund() throws RemoteException
@@ -366,6 +380,8 @@ public class AbrechnungslaufControl extends AbstractControl
       abrechnungslaufList.addColumn("Stichtag", "stichtag",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
       abrechnungslaufList.addColumn("Eingabedatum", "eingabedatum",
+          new DateFormatter(new JVDateFormatTTMMJJJJ()));
+      abrechnungslaufList.addColumn("Austrittsdatum", "austrittsdatum",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
       abrechnungslaufList.addColumn("Zahlungsgrund", "zahlungsgrund");
       abrechnungslaufList.addColumn("Zusatzbeträge", "zusatzbetraege",

--- a/src/de/jost_net/JVerein/gui/input/AbbuchungsmodusInput.java
+++ b/src/de/jost_net/JVerein/gui/input/AbbuchungsmodusInput.java
@@ -52,6 +52,7 @@ public class AbbuchungsmodusInput extends SelectInput
       case FLEXIBEL:
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.ALLE));
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.EINGETRETENEMITGLIEDER));
+        l.add(new AbbuchungsmodusObject(Abrechnungsmodi.ABGEMELDETEMITGLIEDER));
         break;
       case MONATLICH12631:
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.JAHAVIMO));
@@ -63,6 +64,7 @@ public class AbbuchungsmodusInput extends SelectInput
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.VI));
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.MO));
         l.add(new AbbuchungsmodusObject(Abrechnungsmodi.EINGETRETENEMITGLIEDER));
+        l.add(new AbbuchungsmodusObject(Abrechnungsmodi.ABGEMELDETEMITGLIEDER));
         break;
     }
     return PseudoIterator.fromArray(l.toArray(new AbbuchungsmodusObject[l

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
@@ -48,6 +48,7 @@ public class AbrechnungSEPAView extends AbstractView
     }
     group.addLabelPair("Stichtag", control.getStichtag());
     group.addLabelPair("Von Eingabedatum", control.getVondatum());
+    group.addLabelPair("Bis Austrittsdatum", control.getBisdatum());
     group
         .addLabelPair("Zahlungsgrund für Beiträge", control.getZahlungsgrund());
     group.addLabelPair("Zusatzbeträge", control.getZusatzbetrag());

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufView.java
@@ -49,6 +49,7 @@ public class AbrechnungslaufView extends AbstractView
     group.addInput(control.getFaelligkeit2());
     group.addInput(control.getStichtag());
     group.addInput(control.getEingabedatum());
+    group.addInput(control.getAustrittsdatum());
     group.addInput(control.getZahlungsgrund());
     group.addInput(control.getZusatzAbrechnungen());
     group.addInput(control.getBemerkung());

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -251,7 +251,14 @@ public class AbrechnungSEPA
           new Object[] { new java.sql.Date(param.stichtag.getTime()) });
       // Das Mitglied darf noch nicht ausgetreten sein
       list.addFilter("(austritt is null or austritt > ?)",
-          new Object[] { new java.sql.Date(param.stichtag.getTime()) });
+	      new Object[] { new java.sql.Date(param.stichtag.getTime()) });
+      // Bei Abbuchungen im Laufe des Jahres werden nur die Mitglieder
+      // berücksichtigt, die bis zu einem bestimmten Zeitpunkt ausgetreten sind.
+      if (param.bisdatum != null)
+      {
+	      list.addFilter("(austritt <= ?)",
+	          new Object[] { new java.sql.Date(param.bisdatum.getTime()) });
+      }
       // Bei Abbuchungen im Laufe des Jahres werden nur die Mitglieder
       // berücksichtigt, die ab einem bestimmten Zeitpunkt eingetreten sind.
       if (param.vondatum != null)
@@ -728,6 +735,7 @@ public class AbrechnungSEPA
     abrl.setFaelligkeit2(param.faelligkeit2);
     abrl.setDtausdruck(param.sepaprint);
     abrl.setEingabedatum(param.vondatum);
+    abrl.setAustrittsdatum(param.bisdatum);
     abrl.setKursteilnehmer(param.kursteilnehmer);
     abrl.setModus(param.abbuchungsmodus);
     abrl.setStichtag(param.stichtag);

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPAParam.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPAParam.java
@@ -50,6 +50,8 @@ public class AbrechnungSEPAParam
 
   public final Date vondatum;
 
+  public final Date bisdatum;
+
   public final String verwendungszweck;
 
   public final Boolean zusatzbetraege;
@@ -85,6 +87,7 @@ public class AbrechnungSEPAParam
     abbuchungsausgabe = (Abrechnungsausgabe) ac.getAbbuchungsausgabe()
         .getValue();
     vondatum = (Date) ac.getVondatum().getValue();
+    bisdatum = (Date) ac.getBisdatum().getValue();
     verwendungszweck = (String) ac.getZahlungsgrund().getValue();
     zusatzbetraege = (Boolean) ac.getZusatzbetrag().getValue();
     kursteilnehmer = (Boolean) ac.getKursteilnehmer().getValue();

--- a/src/de/jost_net/JVerein/io/MailSender.java
+++ b/src/de/jost_net/JVerein/io/MailSender.java
@@ -50,7 +50,7 @@ import de.willuhn.logging.Logger;
 
 public class MailSender
 {
-  private static final String ISO_8859_15 = "ISO-8859-15";
+  private static final String UTF_8 = "UTF-8";
 
   public static class IMAPCopyData
   {
@@ -208,8 +208,8 @@ public class MailSender
     props.put("mail.smtp.localhost", "localhost");
     props.put("mail.debug", "true");
     props.put("mail.smtp.port", smtp_port);
-    props.put("mail.mime.charset", ISO_8859_15);
-    System.setProperty("mail.mime.charset", "ISO-8859-15");
+    props.put("mail.mime.charset", UTF_8);
+    System.setProperty("mail.mime.charset", UTF_8);
 
     if (smtp_ssl)
     {
@@ -277,18 +277,18 @@ public class MailSender
     boolean html = text.toLowerCase().contains("<html");
 
     MimeBodyPart messageBodyPart = new MimeBodyPart();
-    messageBodyPart.addHeader("Content-Encoding", ISO_8859_15);
+    messageBodyPart.addHeader("Content-Encoding", UTF_8);
     Multipart multipart = new MimeMultipart("mixed");
 
     // Fill the message
     if (html)
     {
-      messageBodyPart.setText(text, ISO_8859_15, "html");
+      messageBodyPart.setText(text, UTF_8, "html");
 
       Multipart alternativeMessagesMultipart = new MimeMultipart("alternative");
 
       MimeBodyPart altMessageBodyPart = new MimeBodyPart();
-      altMessageBodyPart.addHeader("Content-Encoding", ISO_8859_15);
+      altMessageBodyPart.addHeader("Content-Encoding", UTF_8);
       altMessageBodyPart
           .setText(
               "Um diese Email richtig darstellen zu können, erlauben Sie bitte in Ihrem Emailprogramm die Darstellung von HTML-Emails.\n"
@@ -300,7 +300,7 @@ public class MailSender
                           "(?s)<\\s*?(style|Style|STYLE).*?>.*?</\\s*?(style|Style|STYLE)\\s*?>",
                           "").replaceAll("<.*?>", "")
                       .replaceAll("\\n{4,}", "\n\n\n").replaceAll("\\t", ""),
-              ISO_8859_15);
+                      UTF_8);
 
       alternativeMessagesMultipart.addBodyPart(altMessageBodyPart);
       alternativeMessagesMultipart.addBodyPart(messageBodyPart);
@@ -311,7 +311,7 @@ public class MailSender
     }
     else
     {
-      messageBodyPart.setText(text, ISO_8859_15);
+      messageBodyPart.setText(text, UTF_8);
       multipart.addBodyPart(messageBodyPart);
     }
 

--- a/src/de/jost_net/JVerein/keys/Abrechnungsmodi.java
+++ b/src/de/jost_net/JVerein/keys/Abrechnungsmodi.java
@@ -43,6 +43,8 @@ public class Abrechnungsmodi
 
   public static final int EINGETRETENEMITGLIEDER = 99;
 
+  public static final int ABGEMELDETEMITGLIEDER = 100;
+
   private int abrechnungsmodus;
 
   public Abrechnungsmodi(int abrechnungsmodus)
@@ -86,6 +88,8 @@ public class Abrechnungsmodi
         return "Vierteljahres- und Monatsbeiträge";
       case EINGETRETENEMITGLIEDER:
         return "eingetretene Mitglieder";
+      case ABGEMELDETEMITGLIEDER:
+        return "abgemeldete Mitglieder";
       default:
         return null;
     }

--- a/src/de/jost_net/JVerein/rmi/Abrechnungslauf.java
+++ b/src/de/jost_net/JVerein/rmi/Abrechnungslauf.java
@@ -52,6 +52,10 @@ public interface Abrechnungslauf extends DBObject
 
   public void setEingabedatum(Date eingabedatum) throws RemoteException;
 
+  public Date getAustrittsdatum() throws RemoteException;
+
+  public void setAustrittsdatum(Date austrittsdatum) throws RemoteException;
+
   public String getZahlungsgrund() throws RemoteException;
 
   public void setZahlungsgrund(String zahlungsgrund) throws RemoteException;

--- a/src/de/jost_net/JVerein/server/AbrechnungslaufImpl.java
+++ b/src/de/jost_net/JVerein/server/AbrechnungslaufImpl.java
@@ -176,6 +176,23 @@ public class AbrechnungslaufImpl extends AbstractDBObject implements
   }
 
   @Override
+  public Date getAustrittsdatum() throws RemoteException
+  {
+    Date d = (Date) getAttribute("austrittsdatum");
+    if (d == null)
+    {
+      return Einstellungen.NODATE;
+    }
+    return d;
+  }
+
+  @Override
+  public void setAustrittsdatum(Date austrittsdatum) throws RemoteException
+  {
+    setAttribute("austrittsdatum", austrittsdatum);
+  }
+
+  @Override
   public String getZahlungsgrund() throws RemoteException
   {
     return (String) getAttribute("zahlungsgrund");

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0417.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0417.java
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0417 extends AbstractDDLUpdate
+{
+  public Update0417(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("abrechnungslauf",
+      new Column("austrittsdatum", COLTYPE.DATE, 0, "NULL", false, false)));
+  }
+}


### PR DESCRIPTION
Wir buchen in unserem Verein die Mitgliedsbeiträge zum Jahresende ab. Zweimal im Jahr werden Zusatzbeträge abgebucht. Um bei unterjährigen Austritten die Mitgliedsbeiträge vorzeitig (gemeinsam mit den Zusatzbeträgen) abbuchen zu können, habe ich einen neuen Abbuchungsmodus "abgemeldete Mitglieder" hinzugefügt. Damit werden Beiträge für alle Mitglieder abgebucht, die bis zu einem vorgegebenen Datum ausgetreten sind.

Außerdem habe ich die Variable $lastschrift_geschlecht hinzugefügt. Wir sind ein zweisprachiger Verein, und das scheint mir die einfachste Möglichkeit zu sein, um in der Pre-Notification in einer anderen Sprache die richtige Anrede zu verwenden.