### PR TITLE
Change width of MitgliedskontoAuswahlDialog from 600px to 900px

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
@@ -65,7 +65,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
     settings = new de.willuhn.jameica.system.Settings(this.getClass());
     settings.setStoreWhenRead(true);
 
-    this.setSize(600, 700);
+    this.setSize(900, 700);
     this.setTitle("Mitgliedskonto-Auswahl");
     this.buchung = buchung;
     control = new MitgliedskontoControl(null);


### PR DESCRIPTION
Vor diesem Commit ist der Dialog immer zu klein und man kann nicht direkt die Beträge der Soll-Buchungen sehen:
![screenshot from 2019-02-19 16-43-17](https://user-images.githubusercontent.com/601153/53027596-89d09400-3465-11e9-896f-d3ba018c81a4.png)

Besonders, wenn man viele Buchungen hinzufügt, ist das lästig.