### PR TITLE
Use "Egal" as default value for "Differenz" dropdown in Mitgliedskont…

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
@@ -89,7 +89,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
     suNa.setValue(buchung.getName());
     grNurIst.addLabelPair("Name", suNa);
     grNurIst.addLabelPair("Differenz",
-        control.getDifferenz(DIFFERENZ.FEHLBETRAG));
+        control.getDifferenz(DIFFERENZ.EGAL));
     Action action = new Action()
     {
 


### PR DESCRIPTION
…oAuswahlDialog

Da wir die Soll-Buchungen häufiger "überbuchen", wäre es bei uns sehr hilfreich, wenn "Egal" der Default wäre.

Da das vermutlich für den Großteil der JVerein-Nutzer nicht so ist, könnte ich mir vorstellen, dass das eine Einstellmöglichkeit sinnvoll wäre oder dass das Feld seine letzte Variante dauerhaft behält. Scheinbar gibt es da aber auch schon eine Einstellung, die an dieser Stelle aber nicht genutzt wird. Hat das einen Grund?