### PR TITLE
Tabelle ist case-sensitive

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -276,7 +276,7 @@ public class MailControl extends AbstractControl
           {
             SimpleDialog d = new SimpleDialog(SimpleDialog.POSITION_CENTER);
             d.setTitle("Mail bereits versendet");
-            d.setText("Mail wurde bereits an alle Empf√§nger versendet!");
+            d.setText("Mail wurde bereits an alle Empf‰nger versendet!");
             try
             {
               d.open();
@@ -293,8 +293,8 @@ public class MailControl extends AbstractControl
             d.setTitle("Mail senden?");
             d.setText("Diese Mail wurde bereits an "
                 + (getMail().getEmpfaenger().size() - toBeSentCount)
-                + " der gew√§hlten Empf√§nger versendet. Wollen Sie diese Mail an alle weiteren "
-                + toBeSentCount + " Empf√§nger senden?");
+                + " der gew‰hlten Empf‰nger versendet. Wollen Sie diese Mail an alle weiteren "
+                + toBeSentCount + " Empf‰nger senden?");
             try
             {
               Boolean choice = (Boolean) d.open();
@@ -342,7 +342,7 @@ public class MailControl extends AbstractControl
           if (mail.getTxt().length() > 10000)
           {
             throw new ApplicationException(
-                "Maximale L√§nge des Textes 10.000 Zeichen");
+                "Maximale L‰nge des Textes 10.000 Zeichen");
           }
 
           boolean mailAlreadySent = false;
@@ -359,7 +359,7 @@ public class MailControl extends AbstractControl
             YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
             d.setTitle("Mail erneut senden?");
             d.setText(
-                "An mindestens einen Empf√§nger wurde diese Mail bereits versendet. Wollen Sie diese Mail wirklich erneut an alle Empf√§nger senden?");
+                "An mindestens einen Empf‰nger wurde diese Mail bereits versendet. Wollen Sie diese Mail wirklich erneut an alle Empf‰nger senden?");
             try
             {
               Boolean choice = (Boolean) d.open();
@@ -410,8 +410,8 @@ public class MailControl extends AbstractControl
   }
 
   /**
-   * Versende Mail an Empf√§nger. Wenn erneutSenden==false wird Mail nur an
-   * Empf√§nger versendet, die Mail noch nicht erhalten haben.
+   * Versende Mail an Empf‰nger. Wenn erneutSenden==false wird Mail nur an
+   * Empf‰nger versendet, die Mail noch nicht erhalten haben.
    */
   private void sendeMail(final boolean erneutSenden) throws RemoteException
   {
@@ -480,7 +480,7 @@ public class MailControl extends AbstractControl
             }
             else
             {
-              monitor.log(empf.getMailAdresse() + " - √ºbersprungen");
+              monitor.log(empf.getMailAdresse() + " - ¸bersprungen");
             }
             zae++;
             double proz = (double) zae

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -112,7 +112,7 @@ public class MailControl extends AbstractControl
     {
       DBIterator<MailEmpfaenger> it = Einstellungen.getDBService()
           .createList(MailEmpfaenger.class);
-      it.join("MITGLIED");
+      it.join("mitglied");
       it.addFilter("mail = ?", new Object[] { getMail().getID() });
       it.setOrder("order by mitglied.name, mitglied.vorname");
       TreeSet<MailEmpfaenger> empf = new TreeSet<MailEmpfaenger>();
@@ -276,7 +276,7 @@ public class MailControl extends AbstractControl
           {
             SimpleDialog d = new SimpleDialog(SimpleDialog.POSITION_CENTER);
             d.setTitle("Mail bereits versendet");
-            d.setText("Mail wurde bereits an alle Empf‰nger versendet!");
+            d.setText("Mail wurde bereits an alle Empf√§nger versendet!");
             try
             {
               d.open();
@@ -293,8 +293,8 @@ public class MailControl extends AbstractControl
             d.setTitle("Mail senden?");
             d.setText("Diese Mail wurde bereits an "
                 + (getMail().getEmpfaenger().size() - toBeSentCount)
-                + " der gew‰hlten Empf‰nger versendet. Wollen Sie diese Mail an alle weiteren "
-                + toBeSentCount + " Empf‰nger senden?");
+                + " der gew√§hlten Empf√§nger versendet. Wollen Sie diese Mail an alle weiteren "
+                + toBeSentCount + " Empf√§nger senden?");
             try
             {
               Boolean choice = (Boolean) d.open();
@@ -342,7 +342,7 @@ public class MailControl extends AbstractControl
           if (mail.getTxt().length() > 10000)
           {
             throw new ApplicationException(
-                "Maximale L‰nge des Textes 10.000 Zeichen");
+                "Maximale L√§nge des Textes 10.000 Zeichen");
           }
 
           boolean mailAlreadySent = false;
@@ -359,7 +359,7 @@ public class MailControl extends AbstractControl
             YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
             d.setTitle("Mail erneut senden?");
             d.setText(
-                "An mindestens einen Empf‰nger wurde diese Mail bereits versendet. Wollen Sie diese Mail wirklich erneut an alle Empf‰nger senden?");
+                "An mindestens einen Empf√§nger wurde diese Mail bereits versendet. Wollen Sie diese Mail wirklich erneut an alle Empf√§nger senden?");
             try
             {
               Boolean choice = (Boolean) d.open();
@@ -410,8 +410,8 @@ public class MailControl extends AbstractControl
   }
 
   /**
-   * Versende Mail an Empf‰nger. Wenn erneutSenden==false wird Mail nur an
-   * Empf‰nger versendet, die Mail noch nicht erhalten haben.
+   * Versende Mail an Empf√§nger. Wenn erneutSenden==false wird Mail nur an
+   * Empf√§nger versendet, die Mail noch nicht erhalten haben.
    */
   private void sendeMail(final boolean erneutSenden) throws RemoteException
   {
@@ -480,7 +480,7 @@ public class MailControl extends AbstractControl
             }
             else
             {
-              monitor.log(empf.getMailAdresse() + " - ¸bersprungen");
+              monitor.log(empf.getMailAdresse() + " - √ºbersprungen");
             }
             zae++;
             double proz = (double) zae


### PR DESCRIPTION
Beim Aufruf von Mails kam es zu Exceptions, da als Query "select mailempfaenger.* from mailempfaenger, MITGLIED where mail" abgeschickt wurde. Die Tabelle heißt aber "mitglied".