### PR TITLE
Feature/automatische verbuchung von steuern

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.action;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Messaging.BuchungMessage;
+import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -107,15 +108,26 @@ public class BuchungDeleteAction implements Action
         }
         else if (splitbuchung)
         {
-          bu.setDelete(true);
-          Application.getMessagingFactory().sendMessage(new BuchungMessage(bu));
-          count++;
+          if (bu.getDependencyId() == -1) {            
+            bu.setDelete(true);
+            Application.getMessagingFactory().sendMessage(new BuchungMessage(bu));
+            count++;
+          }
+          else {
+            for (Buchung buchung_tmp : SplitbuchungsContainer.get()) {
+              if (buchung_tmp.getDependencyId() == bu.getDependencyId()) {
+                buchung_tmp.setDelete(true);
+                Application.getMessagingFactory().sendMessage(new BuchungMessage(buchung_tmp));
+                count++;
+              }
+            }
+          }
         }
       }
       if (count > 0)
       {
         GUI.getStatusBar().setSuccessText(
-            String.format("%d Buchung" + (b.length != 1 ? "en" : "")
+            String.format("%d Buchung" + (count != 1 ? "en" : "")
                 + " gelöscht.", count));
       }
       else

--- a/src/de/jost_net/JVerein/gui/menu/SplitBuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SplitBuchungMenu.java
@@ -26,6 +26,7 @@ import de.jost_net.JVerein.gui.action.BuchungKontoauszugZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungMitgliedskontoZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
+import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.keys.SplitbuchungTyp;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.willuhn.jameica.gui.Action;
@@ -127,9 +128,18 @@ public class SplitBuchungMenu extends ContextMenu
           try
           {
             Buchung bu = (Buchung) context;
-            bu.setDelete(false);
-            Application.getMessagingFactory()
-                .sendMessage(new BuchungMessage(bu));
+            if (bu.getDependencyId() == -1) {            
+              bu.setDelete(false);
+              Application.getMessagingFactory().sendMessage(new BuchungMessage(bu));
+            }
+            else {
+              for (Buchung buchung_tmp : SplitbuchungsContainer.get()) {
+                if (buchung_tmp.getDependencyId() == bu.getDependencyId()) {
+                  buchung_tmp.setDelete(false);
+                  Application.getMessagingFactory().sendMessage(new BuchungMessage(buchung_tmp));
+                }
+              }
+            }
           }
           catch (RemoteException e)
           {

--- a/src/de/jost_net/JVerein/gui/view/BuchungsartView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsartView.java
@@ -40,6 +40,8 @@ public class BuchungsartView extends AbstractView
     group.addLabelPair("Art", control.getArt());
     group.addLabelPair("Buchungsklasse", control.getBuchungsklasse());
     group.addLabelPair("Spende", control.getSpende());
+    group.addLabelPair("Steuersatz", control.getSteuersatz());
+    group.addLabelPair("Steuer Buchungsart", control.getSteuerBuchungsart());
     // TODO Jo Dokumentation nachpflegen
 
     ButtonArea buttons = new ButtonArea();

--- a/src/de/jost_net/JVerein/io/KontenrahmenImportXML.java
+++ b/src/de/jost_net/JVerein/io/KontenrahmenImportXML.java
@@ -88,6 +88,8 @@ public class KontenrahmenImportXML implements Importer
         {
           buchungsart.setSpende(true);
         }
+        buchungsart.setSteuersatz(buaelement.getAttribute("steuersatz", 0));        
+        buchungsart.setSteuerBuchungsart(buaelement.getAttribute("steuer_buchungsart", null));
         buchungsart.store();
       }
 

--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -29,13 +29,16 @@ import de.willuhn.util.ApplicationException;
 
 public class SplitbuchungsContainer
 {
-
   private static ArrayList<Buchung> splitbuchungen = null;
+
+  private static int dependencyid = 0;
 
   public static void init(Buchung b)
       throws RemoteException, ApplicationException
   {
     splitbuchungen = new ArrayList<>();
+    dependencyid = 0;
+
     // Wenn eine gesplittete Buchung aufgerufen wird, wird die Hauptbuchung
     // gelesen
     if (b.getSplitId() != null)
@@ -76,7 +79,9 @@ public class SplitbuchungsContainer
     }
     while (it.hasNext())
     {
-      SplitbuchungsContainer.add((Buchung) it.next());
+      Buchung buchung = (Buchung) it.next();
+      SplitbuchungsContainer.add(buchung);
+      dependencyid = Math.max(dependencyid, buchung.getDependencyId());
     }
   }
 
@@ -202,5 +207,9 @@ public class SplitbuchungsContainer
         b.store();
       }
     }
+  }
+
+  public static int getNewDependencyId() {
+    return ++dependencyid;
   }
 }

--- a/src/de/jost_net/JVerein/keys/SteuersatzBuchungsart.java
+++ b/src/de/jost_net/JVerein/keys/SteuersatzBuchungsart.java
@@ -1,0 +1,81 @@
+    
+    /**********************************************************************
+ * Copyright (c) by Vinzent Rudolf
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * vinzent.rudolf@web.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.keys;
+
+import java.util.ArrayList;
+
+/**
+ * Steuersatz: Entweder 7%, 19% oder es ist eine Spende
+ */
+
+public class SteuersatzBuchungsart
+{
+  private double steuersatz_;
+
+  public SteuersatzBuchungsart(double steuersatz)
+  {
+    steuersatz_ = steuersatz;
+  }
+
+  public double getSteuersatz()
+  {
+    return steuersatz_;
+  }
+
+  public String getText()
+  {
+    return get(steuersatz_);
+  }
+
+  @Override
+  public String toString()
+  {
+    return get(steuersatz_);
+  }
+
+  public static String get(double steuersatz)
+  {
+    if (steuersatz == 0.00) {
+      return "";
+    }
+    else {
+      return String.format ("%.2f", steuersatz) + "%";
+    }
+  }
+  
+  public static ArrayList<SteuersatzBuchungsart> getArray()
+  {
+    ArrayList<SteuersatzBuchungsart> ret = new ArrayList<>();
+    ret.add(new SteuersatzBuchungsart(0));
+    ret.add(new SteuersatzBuchungsart(19));
+    ret.add(new SteuersatzBuchungsart(7));
+    return ret;
+  }
+
+  @Override
+  public boolean equals(Object obj)
+  {
+    if (obj instanceof SteuersatzBuchungsart)
+    {
+      SteuersatzBuchungsart v = (SteuersatzBuchungsart) obj;
+      return (getSteuersatz() == v.getSteuersatz());
+    }
+    return false;
+  }
+}

--- a/src/de/jost_net/JVerein/keys/SteuersatzBuchungsart.java
+++ b/src/de/jost_net/JVerein/keys/SteuersatzBuchungsart.java
@@ -21,7 +21,7 @@ package de.jost_net.JVerein.keys;
 import java.util.ArrayList;
 
 /**
- * Steuersatz: Entweder 7%, 19% oder es ist eine Spende
+ * Steuersatz: Entweder 7% oder 19%
  */
 
 public class SteuersatzBuchungsart

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -113,6 +113,10 @@ public interface Buchung extends DBObject
 
   public void setSpendenbescheinigungId(Long spendenbescheinigung)
       throws RemoteException;
+        
+  public int getDependencyId() throws RemoteException;
+
+  public void setDependencyId(int dependencyid) throws RemoteException;
 
   public Map<String, Object> getMap(Map<String, Object> map)
       throws RemoteException;

--- a/src/de/jost_net/JVerein/rmi/Buchungsart.java
+++ b/src/de/jost_net/JVerein/rmi/Buchungsart.java
@@ -43,5 +43,12 @@ public interface Buchungsart extends DBObject
   public Boolean getSpende() throws RemoteException;
 
   public void setSpende(Boolean spende) throws RemoteException;
+  
+  public double getSteuersatz() throws RemoteException;
 
+  public void setSteuersatz(double steuersatz) throws RemoteException;
+
+  public Buchungsart getSteuerBuchungsart() throws RemoteException;
+
+  public void setSteuerBuchungsart(String steuer_buchungsart) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -447,6 +447,24 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     setAttribute("spendenbescheinigung", spendenbescheinigung);
   }
+  
+  @Override
+  public int getDependencyId() throws RemoteException
+  {
+    Integer dependencyid = (Integer) getAttribute("dependencyid");
+    if (dependencyid == null) {
+      return -1;
+    }
+    else {
+      return dependencyid.intValue();
+    }
+  }
+
+  @Override
+  public void setDependencyId(int dependencyid) throws RemoteException
+  {
+    setAttribute("dependencyid", dependencyid);
+  }
 
   @Override
   public Map<String, Object> getMap(Map<String, Object> inma)

--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -18,9 +18,11 @@ package de.jost_net.JVerein.server;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.willuhn.datasource.db.AbstractDBObject;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -63,7 +65,7 @@ public class BuchungsartImpl extends AbstractDBObject implements Buchungsart
       }
       if (getNummer() < 0)
       {
-        throw new ApplicationException("Nummer nicht gültig");
+        throw new ApplicationException("Nummer nicht gÃ¼ltig");
       }
     }
     catch (RemoteException e)
@@ -162,6 +164,44 @@ public class BuchungsartImpl extends AbstractDBObject implements Buchungsart
   public void setSpende(Boolean spende) throws RemoteException
   {
     setAttribute("spende", Boolean.valueOf(spende));
+  }
+
+  @Override
+  public double getSteuersatz() throws RemoteException
+  {
+    Double i = (Double) getAttribute("steuersatz");
+    if (i == null)
+    {
+      return 0;
+    }
+    return i.doubleValue();
+  }
+
+  @Override
+  public void setSteuersatz(double steuersatz) throws RemoteException
+  {
+    setAttribute("steuersatz", steuersatz);
+  }
+
+  @Override
+  public Buchungsart getSteuerBuchungsart() throws RemoteException
+  {
+    String id = (String) getAttribute("steuer_buchungsart");
+    if (id == null) {
+      return null;
+    }
+    else {
+      DBIterator<Buchungsart> steuer_buchungsart = Einstellungen.getDBService()
+        .createList(Buchungsart.class);
+        steuer_buchungsart.addFilter("ID = " + id);
+      return steuer_buchungsart.next();
+    }
+  }
+
+  @Override
+  public void setSteuerBuchungsart(String steuer_buchungsart) throws RemoteException
+  {
+    setAttribute("steuer_buchungsart", steuer_buchungsart);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0418.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0418.java
@@ -37,5 +37,7 @@ public class Update0418 extends AbstractDDLUpdate
       new Column("steuersatz", COLTYPE.DOUBLE, 17, "0", false, false)));
     execute(addColumn("buchungsart",
       new Column("steuer_buchungsart", COLTYPE.VARCHAR, 10, null, false, false)));
+    execute(addColumn("buchung",
+      new Column("dependencyid", COLTYPE.INTEGER, 10, "-1", false, false)));
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0418.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0418.java
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (c) by Vinzent Rudolf
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * vinzent.rudolf@web.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0418 extends AbstractDDLUpdate
+{
+  public Update0418(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("buchungsart",
+      new Column("steuersatz", COLTYPE.DOUBLE, 17, "0", false, false)));
+    execute(addColumn("buchungsart",
+      new Column("steuer_buchungsart", COLTYPE.VARCHAR, 10, null, false, false)));
+  }
+}


### PR DESCRIPTION
Hi,

wenn jemand des öfteren Steuern abführen muss, ist es auf Dauer nervig alle Buchungen immer von alleine zu erstellen, daher habe ich folgende Änderungen eingebracht:

- Jeder Buchungsart kann ein Steuersatz hinzugefügt werden. Falls dies genutzt wird, muss gleichzeitig auch eine Buchungsart für die Verbuchung der Steuer ausgewählt werden.
- Wenn in einer Splitbuchung auf eine Buchungsart mit Steuersatz gebucht wird, wird automatisch auch auf die Steuer-Buchungsart die entsprechende Steuer gebucht (mit einem kleinen Postfix für die entsprechende Steuerart, i.e. VSt., MwSt.)
- Damit die Zuordnung nicht verloren geht, enthält jede Buchung eine zusätzliche "DependencyId", welche angibt, welche Buchungen in einer Splitbuchung voneinander abhängig sind. Sollte nun die Buchungsart o.ä. einer dieser Buchungen gelöscht werden, werden die abhängigen Buchungen gelöscht bzw. angepasst. Darüber hinaus werden immer alle gleichzeitig gelöscht oder wiederhergestellt.

- Ausblick: Ich habe den Identifier "DependencyId" genannt, weil ich in Zukunft noch "Splitbuchungs-Vorlagen" einführen möchte: Es wird ein Hauptbetrag vorgegeben, und dann werden 2 oder mehr Buchungen automatisch erzeugt, deren Beträge rel. oder abs. vom Hauptbetrag abhängen.
