### PR TITLE
Erlaube das Erstellen von Spendenbescheinigungen für bis zu 4 Jahre

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -72,7 +72,12 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
     }
     Calendar cal = Calendar.getInstance();
     jahr = new SelectInput(
-        new Object[] { cal.get(Calendar.YEAR), cal.get(Calendar.YEAR) - 1 },
+        new Object[] {
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.YEAR) - 1,
+            cal.get(Calendar.YEAR) - 2,
+            cal.get(Calendar.YEAR) - 3
+        },
         cal.get(Calendar.YEAR));
     jahr.addListener(new Listener()
     {


### PR DESCRIPTION
Offensichtlich nutzen einige die Zeit aktuell für ihre Steuererklärungen - und so kommt es, dass wir auch mal eine Spendenbescheinigung für das vorletzte Jahr ausstellen müssen.

Mit diesem Patch wird das Jahresauswahlfeld auf 4 Jahre erweitert. Das sollte hoffentlich erstmal reichen.