### PR TITLE
Fix: Nullpointer Exception bei Aufruf der Buchungsklassen

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
@@ -83,7 +83,10 @@ public class BuchungsklasseSaldoView extends AbstractView
         });
 
     Calendar calendar = new GregorianCalendar();
-    calendar.setTime(earliest);
+    if (earliest != null)
+    {
+      calendar.setTime(earliest);
+    }
     return calendar.get(Calendar.YEAR);
   }
 


### PR DESCRIPTION
Fixes #55 
Fehler trat nur solange auf, wie noch keine Buchungen angelegt wurden.