### PR TITLE
automatische Zuordnung von Buchungen zu einem Mitgliedskonto

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungMitgliedskontoZuordnungAutomatischAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungMitgliedskontoZuordnungAutomatischAction.java
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.util.Date;
+
+import de.jost_net.JVerein.gui.dialogs.BuchungenMitgliedskontenZuordnungDialog;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.input.DateInput;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class BuchungMitgliedskontoZuordnungAutomatischAction implements Action
+{
+  private DateInput vondatum;
+  private DateInput bisdatum;
+
+  public BuchungMitgliedskontoZuordnungAutomatischAction(DateInput vondatum, DateInput bisdatum) {
+    this.vondatum = vondatum;
+    this.bisdatum = bisdatum;
+  }
+
+ /**
+   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+   */
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    try
+    {
+      BuchungenMitgliedskontenZuordnungDialog d = new BuchungenMitgliedskontenZuordnungDialog((Date)vondatum.getValue(), (Date)bisdatum.getValue());
+      d.open();
+    }
+    catch (OperationCanceledException oce)
+    {
+      Logger.info(oce.getMessage());
+    }
+    catch (ApplicationException ae)
+    {
+      throw ae;
+    }
+    catch (Exception e)
+    {
+      Logger.error("error while assign transfers to members", e);
+      GUI.getStatusBar().setErrorText("Fehler beim Zuordnen von Buchungen zu Mitgliedskonten");
+    }
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -37,6 +37,7 @@ import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.Messaging.BuchungMessage;
 import de.jost_net.JVerein.Queries.BuchungQuery;
 import de.jost_net.JVerein.gui.action.BuchungAction;
+import de.jost_net.JVerein.gui.action.BuchungMitgliedskontoZuordnungAutomatischAction;
 import de.jost_net.JVerein.gui.dialogs.BuchungsjournalSortDialog;
 import de.jost_net.JVerein.gui.dialogs.SammelueberweisungAuswahlDialog;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
@@ -726,6 +727,13 @@ public class BuchungsControl extends AbstractControl
     return b;
   }
 
+  public Button getStarteBuchungMitgliedskontoZuordnungAutomatischButton()
+  {
+    Button b = new Button("Zuordnung", new BuchungMitgliedskontoZuordnungAutomatischAction(getVondatum(), getBisdatum()), null, false,
+            "user-friends.png");
+    return b;
+  }
+
   public Button getStartAuswertungBuchungsjournalButton()
   {
     Button b = new Button("PDF Buchungsjournal", new Action()
@@ -1007,6 +1015,7 @@ public class BuchungsControl extends AbstractControl
       buchungsList.addColumn("Blatt", "blattnummer");
 
       buchungsList.addColumn("Name", "name");
+      buchungsList.addColumn("IBAN oder Kontonummer", "iban");
       buchungsList.addColumn("Verwendungszweck", "zweck", new Formatter()
       {
         @Override

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungUebernahmeProtokollDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungUebernahmeProtokollDialog.java
@@ -92,6 +92,7 @@ public class BuchungUebernahmeProtokollDialog extends AbstractDialog<Buchung>
     bu.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     bu.addColumn("Name", "name");
+    bu.addColumn("IBAN oder Kontonummer", "iban");
     bu.addColumn("Verwendungszweck", "zweck", new Formatter()
     {
 

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungDialog.java
@@ -1,0 +1,507 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.keys.Zahlungsweg;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.datasource.GenericObject;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.CheckboxInput;
+import de.willuhn.jameica.gui.input.DateInput;
+import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.Container;
+import de.willuhn.jameica.gui.util.SimpleContainer;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.BackgroundTask;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.jameica.system.Settings;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+/**
+ * Dialog, ueber den Daten importiert werden koennen.
+ */
+public class BuchungenMitgliedskontenZuordnungDialog extends AbstractDialog<Object>
+{
+  private static final String SETTINGS_PREFIX = "BUCHUNGSZUORDNUNG.";
+  private static final String SETTINGS_NAME_IBAN = SETTINGS_PREFIX + "IBAN";
+  private static final String SETTINGS_NAME_MITGLIEDSNUMMER = SETTINGS_PREFIX + "MITGLIEDSNUMMER";
+  private static final String SETTINGS_NAME_VORNAME_NAME = SETTINGS_PREFIX + "VORNAME_NAME";
+
+  private static final int WINDOW_WIDTH = 620;
+
+  private DateInput     dateFrom = null;
+  private DateInput     dateUntil = null;
+  private CheckboxInput useIban = null;
+  private CheckboxInput useMemberNumber = null;
+  private CheckboxInput useName = null;
+
+  private Settings settings = null;
+
+  /**
+   * ct.
+   * @param bisdatum
+   * @param vondatum
+   * 
+   * @throws RemoteException
+   */
+  public BuchungenMitgliedskontenZuordnungDialog(Date vondatum, Date bisdatum)
+  {
+    super(POSITION_CENTER);
+
+    setTitle("Buchungen zu Mitgliedskonten zuordnen");
+    setSize(WINDOW_WIDTH, SWT.DEFAULT);
+
+    settings = new Settings(this.getClass());
+    settings.setStoreWhenRead(true);
+
+    //Inputs
+    dateFrom = createDateInput(vondatum, true);
+    dateUntil = createDateInput(bisdatum, false);
+    useIban = new CheckboxInput(settings.getBoolean(SETTINGS_NAME_IBAN, true));
+    useMemberNumber = new CheckboxInput(settings.getBoolean(SETTINGS_NAME_MITGLIEDSNUMMER, false));
+    useName = new CheckboxInput(settings.getBoolean(SETTINGS_NAME_VORNAME_NAME, false));
+  }
+
+  private DateInput createDateInput(Date date, boolean isStart)
+  {
+    DateInput returnValue = new DateInput(date, new JVDateFormatTTMMJJJJ());
+    String typeOfInput = isStart ? "Be­ginn" : "Ende";
+    returnValue.setTitle(typeOfInput +  " des Suchbereichs");
+    returnValue.setText("Bitte "+ typeOfInput +" des Suchbereichs wählen");
+    returnValue.setComment("*)");
+    return returnValue;
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#paint(org.eclipse.swt.widgets.Composite)
+   */
+  @Override
+  protected void paint(Composite parent) throws Exception
+  {
+    Container group = new SimpleContainer(parent);
+    group.addText("Bitte wählen Sie den Suchzeitraum und die gewünschte Zuordnungsart aus", true);
+
+    group.addLabelPair("Startdatum", dateFrom);
+    group.addLabelPair("Enddatum", dateUntil);
+    group.addLabelPair("nach eindeutiger IBAN", useIban);
+    group.addLabelPair("nach " + (Einstellungen.getEinstellung().getExterneMitgliedsnummer().booleanValue() ? "Ext. Mitgliedsnummer" : "Mitgliedsnummer"), useMemberNumber);
+    group.addLabelPair("nach eindeutigen Vorname und Nachname", useName);
+    ButtonArea buttons = new ButtonArea();
+
+    Button button = new Button("Zuordnungen suchen", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        doSearchAssignment();
+      }
+    }, null, true, "user-friends.png");
+    buttons.addButton(button);
+    buttons.addButton("Abbrechen", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        throw new OperationCanceledException();
+      }
+    }, null, false, "stop-circle.png");
+    group.addButtonArea(buttons);
+    getShell()
+        .setMinimumSize(getShell().computeSize(WINDOW_WIDTH, SWT.DEFAULT));
+  }
+
+  /**
+   * Ermittelt eine Liste von Buchungen mit Mitgliedskonten und gibt
+   * diese an den BuchungenMitgliedskontenZuordnungVorschauDialog weiter
+   * 
+   */
+  private void doSearchAssignment()
+  {
+    final Date dateFromInput = (Date)dateFrom.getValue();
+    final Date dateUntilInput = (Date)dateUntil.getValue();
+
+    final boolean useIbanInput = Boolean.TRUE.equals(this.useIban.getValue());
+    final boolean useMemberNumberInput = Boolean.TRUE.equals(this.useMemberNumber.getValue());
+    final boolean useNameInput = Boolean.TRUE.equals(this.useName.getValue());
+
+    settings.setAttribute(SETTINGS_NAME_IBAN, useIbanInput);
+    settings.setAttribute(SETTINGS_NAME_MITGLIEDSNUMMER, useMemberNumberInput);
+    settings.setAttribute(SETTINGS_NAME_VORNAME_NAME, useNameInput);
+
+    BackgroundTask t = new BackgroundTask()
+    {
+
+      @Override
+      public void run(ProgressMonitor monitor) throws ApplicationException
+      {
+        try 
+        {
+          boolean externeMitgliedsnummer = Boolean.TRUE.equals(Einstellungen.getEinstellung().getExterneMitgliedsnummer());
+
+          if(!useIbanInput && !useMemberNumberInput && !useNameInput)
+          {
+            GUI.getStatusBar().setErrorText("Es wurde keine Zuordnungsart angegeben.");
+            return;
+          }
+
+          if(dateFromInput == null || dateUntilInput == null)
+          {
+            GUI.getStatusBar().setErrorText("Bitte geben Sie ein Start- und Enddatum ein.");
+            return;
+          }
+
+          if(dateUntilInput.before(dateFromInput))
+          {
+            GUI.getStatusBar().setErrorText("Das Enddatum liegt vor dem Startdatum.");
+            return;
+          }
+
+          Map<String, String> uniqueIbans = new HashMap<>();
+          Set<String> duplicateIbans = new HashSet<>();
+
+          Map<String, String> uniqueIds = new HashMap<>();
+          Set<String> duplicateIds = new HashSet<>();
+
+          Map<String, String> uniqueNames = new HashMap<>();
+          Set<String> duplicateNames = new HashSet<>();
+
+          if(useIbanInput || useMemberNumberInput || useNameInput)
+          {
+            DBIterator<Mitglied> mitglieder = Einstellungen.getDBService().createList(Mitglied.class);
+            mitglieder.addFilter("((eintritt <= ? and (austritt is null or austritt >= ?)) "
+                             + "or (eintritt <= ? and (austritt is null or austritt >= ?)) "
+                             + "or (eintritt > ? and austritt < ?))",
+                dateFromInput, dateFromInput, 
+                dateUntilInput, dateUntilInput,
+                dateFromInput, dateUntilInput
+            );
+            mitglieder.addFilter("zahlungsweg = ?", Zahlungsweg.ÜBERWEISUNG);
+
+            while(mitglieder.hasNext())
+            {
+              Mitglied mitglied = mitglieder.next();
+
+              if(useIbanInput)
+              {
+                processUniqueEntry(mitglied.getIban(), mitglied.getID(), uniqueIbans, duplicateIbans);
+              }
+
+              if(useMemberNumberInput)
+              {
+                if(externeMitgliedsnummer)
+                {
+                  processUniqueEntry(mitglied.getExterneMitgliedsnummer(), mitglied.getID(), uniqueIds, duplicateIds);
+                }
+                else
+                {
+                  uniqueIds.put(mitglied.getID(), mitglied.getID());
+                }
+              }
+
+              if(useNameInput)
+              {
+                processUniqueEntry(concatName(mitglied), mitglied.getID(), uniqueNames, duplicateNames);
+              }
+            }
+          }
+          duplicateIbans.clear();
+          duplicateIds.clear();
+          duplicateNames.clear();
+
+          if(uniqueIbans.isEmpty() && uniqueIds.isEmpty() && uniqueNames.isEmpty())
+          {
+            GUI.getStatusBar().setErrorText("Es wurden keine eindeutigen Mitglieder zum Zuordnen in den gewählten Zeitraum gefunden.");
+            return;
+          }
+
+          DBIterator<Buchung> buchungen = Einstellungen.getDBService().createList(Buchung.class);
+          buchungen.addFilter("datum >= ?", dateFromInput);
+          buchungen.addFilter("datum <= ?", dateUntilInput);
+          buchungen.addFilter("mitgliedskonto is null");
+          buchungen.setOrder("ORDER BY datum");
+
+          List<BookingMemberAccountEntry> assignedBooking = new ArrayList<>();
+          Set<String> usedMemberAccount = new HashSet<>();
+
+          while(buchungen.hasNext()) 
+          {
+            Buchung buchung = buchungen.next();
+
+            String bookingPurpose = getBookingPurpose(buchung);
+            if(assginMemberAccountToBooking(assignedBooking,  usedMemberAccount, dateFromInput, dateUntilInput, buchung, uniqueIbans.get(buchung.getIban()), "IBAN") ||
+                assginMemberAccountToBooking(assignedBooking, usedMemberAccount, dateFromInput, dateUntilInput, buchung, uniqueIds.get(bookingPurpose), externeMitgliedsnummer ? "Ext. Mitgliedsnummer" : "Mitgliedsnummer") ||
+                assginMemberAccountToBooking(assignedBooking, usedMemberAccount, dateFromInput, dateUntilInput, buchung, uniqueNames.get(bookingPurpose), "Vorname und Nachname")) 
+            {
+              continue;
+            }
+          }
+
+          if(assignedBooking.isEmpty())
+          {
+            GUI.getStatusBar().setErrorText("Es wurden keine passenden Buchungen oder Mitgliedskonten zum Zuordnen gefunden.");
+          }
+          else
+          {
+            BuchungenMitgliedskontenZuordnungVorschauDialog userValidationDialog = new BuchungenMitgliedskontenZuordnungVorschauDialog(assignedBooking);
+            userValidationDialog.open();
+          }
+        } 
+        catch (RemoteException e)
+        {
+          Logger.error("error while saving import file", e);
+          throw new ApplicationException("Fehler bei der Zuordnungssuche", e);
+        } 
+        catch (Exception e)
+        {
+          Logger.error("error while opening a dialog", e);
+          throw new ApplicationException("Fehler bei der Durchführung der Zuordnung (Bestätigungsdialog)", e);
+        }
+      }
+
+      @Override
+      public void interrupt()
+      {
+        //
+      }
+
+      @Override
+      public boolean isInterrupted()
+      {
+        return false;
+      }
+    };
+
+    Application.getController().start(t);
+
+    close();
+  }
+
+  private String getBookingPurpose(Buchung buchung) throws RemoteException {
+    String zweck = buchung.getZweck();
+    if(zweck == null) return null;
+    return zweck.replaceAll("\r\n", " ").replaceAll("\r", " ").replaceAll("\n", " ");
+  }
+
+  private boolean assginMemberAccountToBooking(List<BookingMemberAccountEntry> assignedBooking, Set<String> usedMemberAccount, Date dateFromInput, Date dateUntilInput, Buchung buchung, String mitgliedsId, String zuordnungsart)
+      throws RemoteException 
+  {
+    boolean processed = false;
+
+    if(mitgliedsId != null)
+    {
+      //wir wollen das nicht nochmal mit der Buchung probieren, da dies das gleiche Ergebnis wäre
+      processed = true;
+
+      DBIterator<Mitgliedskonto> mitgliedskonten = Einstellungen.getDBService().createList(Mitgliedskonto.class);
+      mitgliedskonten.addFilter("mitglied = ?", mitgliedsId);
+      mitgliedskonten.addFilter("zahlungsweg = ?", Zahlungsweg.ÜBERWEISUNG);
+      mitgliedskonten.addFilter("datum >= ?", dateFromInput);
+      mitgliedskonten.addFilter("datum <= ?", dateUntilInput);
+      mitgliedskonten.setOrder("ORDER BY datum");
+
+      while(mitgliedskonten.hasNext()) 
+      {
+        Mitgliedskonto mitgliedskonto = mitgliedskonten.next();
+
+        if(!usedMemberAccount.contains(mitgliedskonto.getID())) 
+        {
+          BigDecimal ist = convertDoubleToBigDecimal(mitgliedskonto.getIstSumme());
+          BigDecimal soll = convertDoubleToBigDecimal(mitgliedskonto.getBetrag());
+
+          if(soll.subtract(ist).equals(convertDoubleToBigDecimal(buchung.getBetrag()))) {
+            assignedBooking.add(new BookingMemberAccountEntry(buchung, mitgliedskonto, zuordnungsart));
+            usedMemberAccount.add(mitgliedskonto.getID());
+            break;
+          }
+        }
+      }
+    }
+
+    return processed;
+  }
+
+  private BigDecimal convertDoubleToBigDecimal(Double doubleValue)
+  {
+    BigDecimal value = new BigDecimal(doubleValue);
+    return value.setScale(2, RoundingMode.HALF_UP);
+  }
+
+  private String concatName(Mitglied mitglied) throws RemoteException 
+  {
+    if(mitglied.getVorname() == null || mitglied.getVorname().length() == 0) 
+    {
+      return mitglied.getName();
+    } 
+    else 
+    {
+      if(mitglied.getName() == null || mitglied.getName().length() == 0) {
+        return mitglied.getVorname();
+      } 
+      else 
+      {
+        return mitglied.getVorname() + " " + mitglied.getName();
+      }
+    }
+  }
+
+  private void processUniqueEntry(String key, String value, Map<String, String> uniqueKeys, Set<String> duplicateKeys)
+  {
+    if(key != null && key.length() > 0) 
+    {
+      if(uniqueKeys.containsKey(key))
+      {
+        uniqueKeys.remove(key);
+        duplicateKeys.add(key);
+      }
+      else
+      {
+        if(!duplicateKeys.contains(key))
+        {
+          uniqueKeys.put(key, value);
+        }
+      }
+    }
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#getData()
+   */
+  @Override
+  protected Object getData() throws Exception
+  {
+    return null;
+  }
+
+  protected class BookingMemberAccountEntry implements GenericObject
+  {
+    public static final String PREFIX_BUCHUNG = "buchung-";
+    public static final String PREFIX_MITGLIEDSKONTO = "mitgliedskonto-";
+
+    private Buchung buchung;
+    private Mitgliedskonto mitgliedskonto;
+    private String zuordnungsart;
+    
+    BookingMemberAccountEntry(Buchung buchung, Mitgliedskonto mitgliedskonto, String zuordnungsart) 
+    {
+      this.buchung = buchung;
+      this.mitgliedskonto = mitgliedskonto;
+      this.zuordnungsart = zuordnungsart;
+    }
+
+    public Buchung getBuchung()
+    {
+      return buchung;
+    }
+    
+    public Mitgliedskonto getMitgliedskonto()
+    {
+      return mitgliedskonto;
+    }
+
+    @Override
+    public boolean equals(GenericObject arg0) throws RemoteException 
+    {
+      if(arg0 instanceof BookingMemberAccountEntry)
+      {
+        BookingMemberAccountEntry otherValue = (BookingMemberAccountEntry) arg0;
+        return otherValue.getBuchung().equals(buchung) && otherValue.getMitgliedskonto().equals(mitgliedskonto);
+      }
+      return false; 
+    }
+
+    @Override
+    public Object getAttribute(String arg0) throws RemoteException
+    {
+      if(arg0 == null) return null;
+
+      if(arg0.startsWith(PREFIX_BUCHUNG))
+      {
+        return buchung.getAttribute(arg0.substring(PREFIX_BUCHUNG.length()));
+      }
+
+      if(arg0.startsWith(PREFIX_MITGLIEDSKONTO))
+      {
+        return mitgliedskonto.getAttribute(arg0.substring(PREFIX_MITGLIEDSKONTO.length()));
+      }
+
+      if(arg0.equals("id"))
+      {
+        return getID();
+      }
+
+      if(arg0.equals("zuordnungsart"))
+      {
+        return zuordnungsart;
+      }
+      return null;
+    }
+
+    @Override
+    public String[] getAttributeNames() throws RemoteException {
+      List<String> attributeNames = new ArrayList<>();
+      attributeNames.add("id");
+      attributeNames.add("zuordnungsart");
+
+      for(String dao : buchung.getAttributeNames()) {
+        attributeNames.add(PREFIX_BUCHUNG + dao);
+      }
+
+      for(String dao : mitgliedskonto.getAttributeNames()) {
+        attributeNames.add(PREFIX_MITGLIEDSKONTO + dao);
+      }
+
+      return attributeNames.toArray(new String[0]);
+    }
+
+    @Override
+    public String getID() throws RemoteException {
+      return buchung.getID() +"."+ mitgliedskonto.getID();
+    }
+
+    @Override
+    public String getPrimaryAttribute() throws RemoteException {
+      return "id";
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungVorschauDialog.java
@@ -1,0 +1,176 @@
+/**********************************************************************
+ * basiert auf dem KontoAuswahlDialog aus Hibiscus
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.rmi.RemoteException;
+import java.util.List;
+
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.action.BuchungsListeAction;
+import de.jost_net.JVerein.gui.dialogs.BuchungenMitgliedskontenZuordnungDialog.BookingMemberAccountEntry;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.formatter.Formatter;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.BackgroundTask;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+/**
+ * Ein Dialog, der die automatisch ermittelten Zuordnungen zwischen Buchung
+ * und Mitgliedskonto anzeigt und bei Bestätigung persistiert 
+ */
+public class BuchungenMitgliedskontenZuordnungVorschauDialog extends AbstractDialog<Object>
+{
+  private List<BookingMemberAccountEntry> assignedBooking;
+
+  public BuchungenMitgliedskontenZuordnungVorschauDialog(List<BookingMemberAccountEntry> assignedBooking)
+  {
+    super(AbstractDialog.POSITION_CENTER);
+    super.setSize(1400, 400);
+    this.setTitle("Buchungszuordnung bestätigen");
+    this.assignedBooking = assignedBooking;
+  }
+
+  @Override
+  protected void paint(Composite parent) throws Exception
+  {
+    final TablePart bu = new TablePart(assignedBooking, null);
+
+    if (Einstellungen.getEinstellung().getExterneMitgliedsnummer().booleanValue())
+    {
+      bu.addColumn("Ext. Mitgliedsnummer", BookingMemberAccountEntry.PREFIX_MITGLIEDSKONTO + "mitglied.externemitgliedsnummer");
+    }
+    else
+    {
+      bu.addColumn("Mitgliedsnummer", BookingMemberAccountEntry.PREFIX_MITGLIEDSKONTO + "mitglied.id");
+    }
+
+    bu.addColumn("Anrede", BookingMemberAccountEntry.PREFIX_MITGLIEDSKONTO + "mitglied.anrede");
+    bu.addColumn("Vorname", BookingMemberAccountEntry.PREFIX_MITGLIEDSKONTO + "mitglied.vorname");
+    bu.addColumn("Name", BookingMemberAccountEntry.PREFIX_MITGLIEDSKONTO + "mitglied.name");
+    bu.addColumn("Abrechnungslaufnummer", BookingMemberAccountEntry.PREFIX_MITGLIEDSKONTO + "abrechnungslauf.id");
+    bu.addColumn("Buchungsnummer", BookingMemberAccountEntry.PREFIX_BUCHUNG + "id");
+    bu.addColumn("IBAN oder Kontonummer", BookingMemberAccountEntry.PREFIX_BUCHUNG + "iban");
+    bu.addColumn("Betrag", BookingMemberAccountEntry.PREFIX_BUCHUNG + "betrag", new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    bu.addColumn("Verwendungszweck", BookingMemberAccountEntry.PREFIX_BUCHUNG + "zweck", new Formatter()
+    {
+      @Override
+      public String format(Object value)
+      {
+        if (value == null)
+        {
+          return null;
+        }
+        String s = value.toString();
+        s = s.replaceAll("\r\n", " ");
+        s = s.replaceAll("\r", " ");
+        s = s.replaceAll("\n", " ");
+        return s;
+      }
+    });
+    bu.addColumn("Buchungsdatum", BookingMemberAccountEntry.PREFIX_BUCHUNG + "datum", new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    bu.addColumn("Zuordnungsart", "zuordnungsart");
+
+    bu.setRememberColWidths(true);
+    bu.paint(parent);
+
+    ButtonArea b = new ButtonArea();
+    b.addButton("Zuordnen", new Action()
+    {
+      @Override
+      public void handleAction(Object context)
+      {
+        persistAssignment();
+      }
+    }, null, false, "ok.png");
+    
+    b.addButton("Abbrechen", new Action()
+    {
+      @Override
+      public void handleAction(Object context)
+      {
+        close();
+      }
+    }, null, false, "window-close.png");
+    b.paint(parent);
+  }
+
+  protected void persistAssignment()
+  {
+
+    BackgroundTask t = new BackgroundTask()
+    {
+
+      @Override
+      public void run(ProgressMonitor monitor) throws ApplicationException
+      {
+
+        try
+        {
+          for(BookingMemberAccountEntry dao : assignedBooking)
+          {
+            dao.getBuchung().setMitgliedskonto(dao.getMitgliedskonto());
+            dao.getBuchung().store();
+          }
+
+          //Darstellung aktualisieren
+          new BuchungsListeAction().handleAction(this);
+
+          GUI.getStatusBar().setSuccessText("Die Zuordnung wurde erfolgreich durchgeführt");
+        }
+        catch (RemoteException e) {
+          Logger.error("error while assignment", e);
+          throw new ApplicationException("Fehler bei der Durchführung der Zuordnung", e);
+        }
+      }
+      
+      @Override
+      public void interrupt()
+      {
+        //
+      }
+
+      @Override
+      public boolean isInterrupted()
+      {
+        return false;
+      }
+    };
+
+    Application.getController().start(t);
+
+    close();
+  }
+
+  @Override
+  protected Object getData() throws Exception
+  {
+    return null;
+  }
+}

--- a/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
@@ -98,6 +98,7 @@ public class BuchungslisteView extends AbstractView
     buttons.addButton(control.getStartAuswertungBuchungsjournalButton());
     buttons.addButton(control.getStartAuswertungEinzelbuchungenButton());
     buttons.addButton(control.getStartAuswertungSummenButton());
+    buttons.addButton(control.getStarteBuchungMitgliedskontoZuordnungAutomatischButton());
     buttons.addButton("neu", new BuchungNeuAction(), control, false,
         "file.png");
     buttons.paint(this.getParent());

--- a/src/de/jost_net/JVerein/io/Buchungsuebernahme.java
+++ b/src/de/jost_net/JVerein/io/Buchungsuebernahme.java
@@ -146,6 +146,7 @@ public class Buchungsuebernahme
         b.setUmsatzid(new Integer(u.getID()));
         b.setKonto(kto);
         b.setName(u.getGegenkontoName());
+        b.setIban(u.getGegenkontoNummer());
         b.setBetrag(u.getBetrag());
         b.setZweck(u.getZweck());
         String[] moreLines = u.getWeitereVerwendungszwecke();

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -47,6 +47,10 @@ public interface Buchung extends DBObject
 
   public void setName(String name) throws RemoteException;
 
+  public String getIban() throws RemoteException;
+
+  public void setIban(String iban) throws RemoteException;
+
   public double getBetrag() throws RemoteException;
 
   public void setBetrag(double betrag) throws RemoteException;

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -255,6 +255,18 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   }
 
   @Override
+  public void setIban(String iban) throws RemoteException
+  {
+    setAttribute("iban", iban);
+  }
+
+  @Override
+  public String getIban() throws RemoteException
+  {
+    return (String) getAttribute("iban");
+  }
+
+  @Override
   public double getBetrag() throws RemoteException
   {
     Double d = (Double) getAttribute("betrag");

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0418.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0418.java
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * JVerein - Mitgliederverwaltung und einfache Buchhaltung für Vereine
+ * Copyright (c) by Heiner Jostkleigrewe
+ * Copyright (c) 2015 by Thomas Hooge
+ * Main Project: heiner@jverein.dem  http://www.jverein.de/
+ * Module Author: thomas@hoogi.de, http://www.hoogi.de/
+ *
+ * This file is part of JVerein.
+ *
+ * JVerein is free software: you can redistribute it and/or modify
+ * it under the terms of the  GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JVerein is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0418 extends AbstractDDLUpdate
+{
+  public Update0418(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    // Startdatum des Projektes
+    execute(addColumn("buchung",
+      new Column("iban", COLTYPE.VARCHAR, 34, "NULL", false, false)));
+
+  }
+}


### PR DESCRIPTION
In der Ansicht Buchführung -> Buchungen gibt es den neuen Button „Zuordnung“, mit dem eine automatische Zuordnung von Buchungen zu Mitgliedskonten vorgenommen werden kann. Diese kann auf Basis einer eindeutigen IBAN, der Mitgliedsnummer im Verwendungszweck und/oder den eindeutigen Vor- und Nachname im Verwendungszweck vorgenommen werden. Über das Start- und Enddatum kann der Suchbereich von aktiven Mitgliedern, Buchungen und Mitgliedskonten eingeschränkt werden.

![1](https://user-images.githubusercontent.com/68302371/87476829-5593df80-c627-11ea-8de3-c50e23cb10f2.png)


Folgende Zuordnungsregeln sind dabei implementiert worden:

- Ist eine IBAN oder der Vor- und Nachname über den angegeben Suchzeitraum eines aktiven Mitglieds nicht eindeutig, findet keine Zuordnung mit dieser Zuordnungsart für dieses Mitglied statt.
- Wurden mehrere Zuordnungsarten auf einmal angegeben (IBAN, Mitgliedsnummer, Vor- und Nachname) wird eine Zuordnung in der genau dieser Reihenfolge versucht.
- Wurde unter Administration -> Einstellungen -> Anzeige „externe Mitgliedsnummer“ angegeben, wird anstatt der Mitgliedsnummer mit der externe Mitgliedsnummer im Verwendungszweck gesucht, falls diese Zuordnungsart gewählt wurde
- eine Zuordnung findet nur statt, wenn sowohl das Mitglied als auch das Mitgliedskonto den Zahlungsweg Überweisung aufweist
- Der Betrag der Buchung muss genau mit dem offenen Betrag des Mitgliedskontos übereinstimmen, damit eine Zuordnung erfolgt
- Gibt es mehrere Buchungen und Mitgliedskonten, die in den angegebenen Zeitraum passen würden, erfolgt die Zuordnung mit dem jeweils ältesten zuerst

Nach der Suche wird ein Dialog angezeigt, der die Zuordnungen dem Nutzer präsentiert. Dieser kann diese Zuordnungen auf Wunsch dann persistieren lassen.

![2](https://user-images.githubusercontent.com/68302371/87476918-7f4d0680-c627-11ea-8433-82309954bd32.png)
