### PR TITLE
Sammelbescheinigung - Anpassung Buchungsliste

### DIFF
--- a/src/de/jost_net/JVerein/Variable/SpendenbescheinigungVar.java
+++ b/src/de/jost_net/JVerein/Variable/SpendenbescheinigungVar.java
@@ -28,6 +28,10 @@ public enum SpendenbescheinigungVar {
   ERSATZAUFWENDUNGEN_JA("spendenbescheinigung_ersatzaufwendungen_ja"), //
   ERSATZAUFWENDUNGEN_NEIN("spendenbescheinigung_ersatzaufwendungen_nein"), //
   BUCHUNGSLISTE("spendenbescheinigung_buchungsliste"), //
+  BUCHUNGSLISTE_DATEN("spendenbescheinigung_buchungsliste_daten"), //
+  BUCHUNGSLISTE_ART("spendenbescheinigung_buchungsliste_art"), //
+  BUCHUNGSLISTE_VERZICHT("spendenbescheinigung_buchungsliste_verzicht"), //
+  BUCHUNGSLISTE_BETRAG("spendenbescheinigung_buchungsliste_betrag"), //
   BEZEICHNUNGSACHZUWENDUNG("spendenbescheinigung_bezeichnungsachzuwendung"), //
   HERKUNFTSACHZUWENDUNG("spendenbescheinigung_herkunftsachzuwendung"), //
   UNTERLAGENWERTERMITTUNG("spendenbescheinigung_unterlagenwertermittlung");//

--- a/src/de/jost_net/JVerein/gui/action/FormularAnzeigeAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FormularAnzeigeAction.java
@@ -208,6 +208,33 @@ public class FormularAnzeigeAction implements Action
       bl.append(StringTool.lpad(str, colBetragLen));
       bl.append(newLineStr);
       map.put(SpendenbescheinigungVar.BUCHUNGSLISTE.getName(), bl.toString());
+
+      StringBuilder bl_daten = new StringBuilder();
+      bl_daten.append("13.02.2008");
+      bl_daten.append(newLineStr);
+      bl_daten.append("12.11.2008");
+      map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_DATEN.getName(), bl_daten.toString());
+
+      StringBuilder bl_art = new StringBuilder();
+      bl_art.append("Beitrag");
+      bl_art.append(newLineStr);
+      bl_art.append("Spende");
+      map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_ART.getName(), bl_art.toString());
+
+      StringBuilder bl_verzicht = new StringBuilder();
+      bl_verzicht.append("nein");
+      bl_verzicht.append(newLineStr);
+      bl_verzicht.append("ja");
+      map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_VERZICHT.getName(), bl_verzicht.toString());
+
+      StringBuilder bl_betrag = new StringBuilder();
+      str = Einstellungen.DECIMALFORMAT.format(15.0);
+      bl_betrag.append(StringTool.lpad(str, colBetragLen));
+      bl_betrag.append(newLineStr);
+      str = Einstellungen.DECIMALFORMAT.format(1234.96);
+      bl_betrag.append(StringTool.lpad(str, colBetragLen));
+      map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_BETRAG.getName(), bl_betrag.toString());
+
       map.put(SpendenbescheinigungVar.BEZEICHNUNGSACHZUWENDUNG.getName(),
           "gebrauchter Tisch");
       map.put(SpendenbescheinigungVar.HERKUNFTSACHZUWENDUNG.getName(),

--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -679,6 +679,10 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
       map.put(SpendenbescheinigungVar.SPENDENZEITRAUM.getName(),
           String.format("%s bis %s", spendedatum, zeitraumende));
       StringBuilder bl = new StringBuilder();
+      StringBuilder bl_daten = new StringBuilder();
+      StringBuilder bl_art = new StringBuilder();
+      StringBuilder bl_verzicht = new StringBuilder();
+      StringBuilder bl_betrag = new StringBuilder();
       if (gc.get(GregorianCalendar.YEAR) <= 2012)
       {
         bl.append(StringTool.rpad("Datum", 10));
@@ -782,11 +786,15 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
         {
           bl.append(StringTool.rpad(
               new JVDateFormatTTMMJJJJ().format(b.getDatum()), colDatumLen));
+          bl_daten.append(new JVDateFormatTTMMJJJJ().format(b.getDatum()));
+          bl_daten.append(newLineStr);
           bl.append("  ");
           if (printBuchungsart)
           {
             bl.append(StringTool.rpad(b.getBuchungsart().getBezeichnung(),
                 colArtLen));
+            bl_art.append(b.getBuchungsart().getBezeichnung());
+            bl_art.append(newLineStr);
           }
           else
           {
@@ -797,16 +805,21 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
           {
             bl.append(StringTool.rpad(
                 StringTool.lpad("ja", colVerzichtLen / 2 - 2), colVerzichtLen));
+            bl_verzicht.append("ja");
           }
           else
           {
             bl.append(
                 StringTool.rpad(StringTool.lpad("nein", colVerzichtLen / 2 - 2),
                     colVerzichtLen));
+            bl_verzicht.append("nein");
           }
+          bl_verzicht.append(newLineStr);
           bl.append("  ");
           String str = Einstellungen.DECIMALFORMAT.format(b.getBetrag());
           bl.append(StringTool.lpad(str, colBetragLen));
+          bl_betrag.append(StringTool.lpad(str, colBetragLen));
+          bl_betrag.append(newLineStr);
           bl.append(newLineStr);
         }
 
@@ -832,6 +845,10 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
         bl.append(newLineStr);
       }
       map.put(SpendenbescheinigungVar.BUCHUNGSLISTE.getName(), bl.toString());
+      map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_DATEN.getName(), bl_daten.toString());
+      map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_ART.getName(), bl_art.toString());
+      map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_VERZICHT.getName(), bl_verzicht.toString());
+      map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_BETRAG.getName(), bl_betrag.toString());
     }
     else
     {


### PR DESCRIPTION
Durch vier neue Variablen können die Spalten der Buchungsliste einzeln in das Formular eingesetzt werden. Somit muss nicht die gesamte Tabelle mit Festbreiten-Schriftart gesetzt werden.

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>